### PR TITLE
Added updateIndicatorOnClick option. Updated documentation

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -181,6 +181,12 @@
                     <td>Defines whether to use the Bootstrap Tooltip as its tooltip rather than the original title attribute in the anchor tag &lt;a&gt;. See <a href="#use-bootstrap-tooltip" title="Click to see Use Bootstrap Tooltip example">Use Bootstrap Tooltip example</a> for more detail.</td>
                 </tr>
                 <tr>
+                    <td class="bp-example-docs-option-attr">updateIndicatorOnClick</td>
+                    <td>boolean</td>
+                    <td>true</td>
+                    <td>Defines whether the current page indicator gets updated immeditaley on click or only after a page refresh.</td>
+                </tr>
+                <tr>
                     <td class="bp-example-docs-option-attr">bootstrapTooltipOptions</td>
                     <td>object</td>
                     <td></td>

--- a/src/bootstrap-paginator.js
+++ b/src/bootstrap-paginator.js
@@ -204,25 +204,26 @@
                 page = event.data.page;
 
             this.$element.trigger("page-clicked", [event, type, page]);
+            if(this.options.updateIndicatorOnClick){
+                //show the corresponding page and retrieve the newly built item related to the page clicked before for the event return
+                switch (type) {
 
-            //show the corresponding page and retrieve the newly built item related to the page clicked before for the event return
-            switch (type) {
-
-            case "first":
-                this.showFirst();
-                break;
-            case "prev":
-                this.showPrevious();
-                break;
-            case "next":
-                this.showNext();
-                break;
-            case "last":
-                this.showLast();
-                break;
-            case "page":
-                this.show(page);
-                break;
+                case "first":
+                    this.showFirst();
+                    break;
+                case "prev":
+                    this.showPrevious();
+                    break;
+                case "next":
+                    this.showNext();
+                    break;
+                case "last":
+                    this.showLast();
+                    break;
+                case "page":
+                    this.show(page);
+                    break;
+                }
             }
 
         },
@@ -556,6 +557,7 @@
         onPageChanged: null,
         useBootstrapTooltip: false,
         shouldShowPage: true,
+        updateIndicatorOnClick: true,
         itemTexts: function (type, page, current) {
             switch (type) {
             case "first":


### PR DESCRIPTION
When pageUrl is set, and the page refreshes on click, I noticed that the paginator gets updated immediately, and if the page takes a little time to load, it just looks wrong. Therefore, I added an option that allows the user to turn off the switching of the page indicator immediately on click. I also updated the documentation.
