### PR TITLE
Fix bug when first/next/prev/last were set to be "on" all the time

### DIFF
--- a/src/bootstrap-paginator.js
+++ b/src/bootstrap-paginator.js
@@ -572,7 +572,7 @@
         bootstrapMajorVersion: 2,
         listContainerClass: "",
         itemContainerClass: function (type, page, current) {
-            return (page === current) ? "active" : "";
+            return (page === current && type === "page") ? "active" : "";
         },
         itemContentClass: function (type, page, current) {
             return "";

--- a/src/bootstrap-paginator.js
+++ b/src/bootstrap-paginator.js
@@ -572,7 +572,7 @@
         bootstrapMajorVersion: 2,
         listContainerClass: "",
         itemContainerClass: function (type, page, current) {
-            return (page === current) ? "active" : "";
+            return (page === current && type == "page") ? "active" : "";
         },
         itemContentClass: function (type, page, current) {
             return "";


### PR DESCRIPTION
I wanted a configuration where the first/prev/next/last buttons were on all the time, but since the 1 was being passed in as the page number for these buttons, they would be marked as active when the first or last page was active.

This checks that the element we are adding "active" to is actually a "page"...
